### PR TITLE
Dependency determination

### DIFF
--- a/src/deps/zcl_abaplint_deps_find.clas.abap
+++ b/src/deps/zcl_abaplint_deps_find.clas.abap
@@ -492,20 +492,6 @@ CLASS ZCL_ABAPLINT_DEPS_FIND IMPLEMENTATION.
 
 * find just the domain for the data element if exists, ignores value tables and more
 
-*    DATA: lv_domname TYPE dd04l-domname
-*          ls_tadir   LIKE LINE OF ct_tadir
-*
-*    SELECT SINGLE domname FROM dd04l
-*      INTO lv_domname
-*      WHERE rollname = iv_name
-*      AND as4local = 'A'
-*      AND as4vers = 0
-*    IF sy-subrc = 0 AND NOT lv_domname IS INITIAL
-*      ls_tadir-ref_obj_type = 'DOMA'
-*      ls_tadir-ref_obj_name = lv_domname
-*      INSERT ls_tadir INTO TABLE ct_tadir
-*    ENDIF
-
     DATA ls_x030l TYPE x030l.
     DATA lv_tabname TYPE dd02l-tabname.
     DATA ls_tadir LIKE LINE OF ct_tadir.
@@ -838,6 +824,7 @@ CLASS ZCL_ABAPLINT_DEPS_FIND IMPLEMENTATION.
     DATA ls_wbcrossgt LIKE LINE OF it_wbcrossgt.
     DATA ls_tadir LIKE LINE OF ct_tadir.
     DATA lv_clstype TYPE seoclass-clstype.
+    DATA lv_name TYPE badi_spot.
 
     LOOP AT it_wbcrossgt INTO ls_wbcrossgt.
       CASE ls_wbcrossgt-otype.
@@ -845,7 +832,7 @@ CLASS ZCL_ABAPLINT_DEPS_FIND IMPLEMENTATION.
           SELECT SINGLE clstype FROM seoclass INTO lv_clstype WHERE clsname = ls_wbcrossgt-name(30).
           IF sy-subrc <> 0.
             "Decide if Enhancement Spot
-            SELECT COUNT( * ) FROM badi_spot WHERE badi_name = ls_wbcrossgt-name.
+            SELECT SINGLE badi_name FROM badi_spot INTO lv_name WHERE badi_name = ls_wbcrossgt-name.
             IF sy-subrc = 0.
               CLEAR ls_tadir.
               ls_tadir-ref_obj_type = 'ENHS'.

--- a/src/deps/zcl_abaplint_deps_find.clas.abap
+++ b/src/deps/zcl_abaplint_deps_find.clas.abap
@@ -538,7 +538,7 @@ CLASS ZCL_ABAPLINT_DEPS_FIND IMPLEMENTATION.
 
   METHOD find_tabl_dependencies.
 
-    DATA lv_tabname TYPE  dd02l-tabname.
+    DATA lv_tabname TYPE dd02l-tabname.
     DATA ls_tadir LIKE LINE OF rt_tadir.
     DATA lt_x031l TYPE STANDARD TABLE OF x031l.
 

--- a/src/deps/zcl_abaplint_deps_find.clas.abap
+++ b/src/deps/zcl_abaplint_deps_find.clas.abap
@@ -216,12 +216,14 @@ CLASS ZCL_ABAPLINT_DEPS_FIND IMPLEMENTATION.
 
     CASE lv_object.
       WHEN 'INCL'.
-        lv_object = 'PROG'.
+        rs_object-object = 'PROG'.
+        rs_object-obj_name = lv_object_name.
       WHEN 'STRU'.
-        lv_object = 'TABL'.
+        rs_object-object = 'TABL'.
+        rs_object-obj_name = lv_object_name.
       WHEN 'MESS'.
-        lv_object = 'MSAG'.
-        lv_object_name = iv_encl_object.
+        rs_object-object = 'MSAG'.
+        rs_object-obj_name = iv_encl_object.
       WHEN OTHERS.
 
 * 1. Determine if R3TR already

--- a/src/deps/zcl_abaplint_deps_find.clas.abap
+++ b/src/deps/zcl_abaplint_deps_find.clas.abap
@@ -5,7 +5,8 @@ CLASS zcl_abaplint_deps_find DEFINITION
   PUBLIC SECTION.
 
     TYPES: BEGIN OF ty_options,
-             max_level TYPE i,
+             max_level         TYPE i,
+             continue_into_sap TYPE abap_bool,
            END OF ty_options.
 
     METHODS constructor
@@ -663,7 +664,8 @@ CLASS ZCL_ABAPLINT_DEPS_FIND IMPLEMENTATION.
 * if SAP object, do not go deeper
 *
 * TODO: when is this valid? add as configuration in constructor?
-    IF NOT ( ( ls_tadir_obj-author = 'SAP'
+    IF ms_options-continue_into_sap = abap_true OR
+      NOT ( ( ls_tadir_obj-author = 'SAP'
            OR ls_tadir_obj-author = 'SAP*' )
            AND ls_tadir_obj-srcsystem = 'SAP' ).
 *

--- a/src/deps/zcl_abaplint_deps_find.clas.abap
+++ b/src/deps/zcl_abaplint_deps_find.clas.abap
@@ -719,8 +719,10 @@ CLASS ZCL_ABAPLINT_DEPS_FIND IMPLEMENTATION.
 
     ls_type-obj_type = 'TABL'.
     rs_types-tabl = zcl_abapgit_objects=>is_supported( ls_type ).
-    ls_type-obj_type = 'SHLP'.
-    rs_types-shlp = zcl_abapgit_objects=>is_supported( ls_type ).
+
+* not needed by abaplint yet
+*    ls_type-obj_type = 'SHLP'
+*    rs_types-shlp = zcl_abapgit_objects=>is_supported( ls_type )
 
 * handled manually in the code
     rs_types-doma = abap_false.

--- a/src/deps/zcl_abaplint_deps_find.clas.abap
+++ b/src/deps/zcl_abaplint_deps_find.clas.abap
@@ -4,9 +4,13 @@ CLASS zcl_abaplint_deps_find DEFINITION
 
   PUBLIC SECTION.
 
+    TYPES: BEGIN OF ty_options,
+             max_level TYPE i,
+           END OF ty_options.
+
     METHODS constructor
       IMPORTING
-        !iv_max_level TYPE i DEFAULT 20 .
+        is_options TYPE ty_options OPTIONAL.
     METHODS find_by_item
       IMPORTING
         !iv_object_type TYPE trobjtype
@@ -43,7 +47,7 @@ CLASS zcl_abaplint_deps_find DEFINITION
     TYPES:
       ty_tadir_tt TYPE SORTED TABLE OF ty_tadir WITH UNIQUE KEY ref_obj_type ref_obj_name .
 
-    DATA mv_max_level TYPE i .
+    DATA ms_options TYPE ty_options.
 
     METHODS convert_senvi_to_tadir
       IMPORTING
@@ -149,7 +153,12 @@ CLASS ZCL_ABAPLINT_DEPS_FIND IMPLEMENTATION.
 
 
   METHOD constructor.
-    mv_max_level = iv_max_level.
+
+    ms_options = is_options.
+    IF ms_options-max_level IS INITIAL.
+      ms_options-max_level = 20 .
+    ENDIF.
+
     ms_types = prepare_supported_types( ).
   ENDMETHOD.
 
@@ -473,7 +482,7 @@ CLASS ZCL_ABAPLINT_DEPS_FIND IMPLEMENTATION.
         AND name <> iv_name.
     ENDIF.
 
-    IF iv_level < mv_max_level.
+    IF iv_level < ms_options-max_level.
       resolve(
         EXPORTING
           it_wbcrossgt = lt_wbcrossgt
@@ -482,7 +491,7 @@ CLASS ZCL_ABAPLINT_DEPS_FIND IMPLEMENTATION.
     ELSE.
       RAISE EXCEPTION TYPE zcx_abaplint_error
         EXPORTING
-          message = |Max depth { mv_max_level } reached for class { lv_clsname }. Exiting dependency walk|.
+          message = |Max depth { ms_options-max_level } reached for class { lv_clsname }. Exiting dependency walk|.
     ENDIF.
 
   ENDMETHOD.

--- a/src/deps/zcl_abaplint_deps_find.clas.testclasses.abap
+++ b/src/deps/zcl_abaplint_deps_find.clas.testclasses.abap
@@ -14,7 +14,13 @@ ENDCLASS.
 CLASS ltcl_find_by_item IMPLEMENTATION.
 
   METHOD setup.
-    CREATE OBJECT mo_cut.
+    DATA ls_options TYPE zcl_abaplint_deps_find=>ty_options.
+
+    ls_options-continue_into_sap = abap_true.
+
+    CREATE OBJECT mo_cut
+      EXPORTING
+        is_options = ls_options.
   ENDMETHOD.
 
   METHOD txmilograw.

--- a/src/deps/zcl_abaplint_deps_find.clas.testclasses.abap
+++ b/src/deps/zcl_abaplint_deps_find.clas.testclasses.abap
@@ -6,6 +6,7 @@ CLASS ltcl_find_by_item DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLES
 
     METHODS:
       setup,
+      usr02 FOR TESTING RAISING cx_static_check,
       txmilograw FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.
@@ -21,6 +22,7 @@ CLASS ltcl_find_by_item IMPLEMENTATION.
     CREATE OBJECT mo_cut
       EXPORTING
         is_options = ls_options.
+
   ENDMETHOD.
 
   METHOD txmilograw.
@@ -46,6 +48,34 @@ CLASS ltcl_find_by_item IMPLEMENTATION.
       lower  = 20
       upper  = 50
       number = lines( lt_results ) ).
+
+  ENDMETHOD.
+
+  METHOD usr02.
+
+    DATA: lt_results TYPE zif_abapgit_definitions=>ty_tadir_tt.
+
+    lt_results = mo_cut->find_by_item(
+      iv_object_type = 'TABL'
+      iv_object_name = 'USR02' ).
+
+    BREAK-POINT.
+
+*    READ TABLE lt_results WITH KEY object = 'DTEL' obj_name = 'XMILOGID' TRANSPORTING NO FIELDS.
+*    cl_abap_unit_assert=>assert_subrc( ).
+*    READ TABLE lt_results WITH KEY object = 'DOMA' obj_name = 'XMILOGID' TRANSPORTING NO FIELDS.
+*    cl_abap_unit_assert=>assert_subrc( ).
+*
+*    READ TABLE lt_results WITH KEY object = 'TABL' obj_name = 'SXMILOGADM' TRANSPORTING NO FIELDS.
+*    cl_abap_unit_assert=>assert_subrc( ).
+*    READ TABLE lt_results WITH KEY object = 'TABL' obj_name = 'SXMIMSGRAW' TRANSPORTING NO FIELDS.
+*    cl_abap_unit_assert=>assert_subrc( ).
+*
+** not sure the result is the same across systems/versions
+*    cl_abap_unit_assert=>assert_number_between(
+*      lower  = 20
+*      upper  = 50
+*      number = lines( lt_results ) ).
 
   ENDMETHOD.
 

--- a/src/deps/zcl_abaplint_deps_find.clas.testclasses.abap
+++ b/src/deps/zcl_abaplint_deps_find.clas.testclasses.abap
@@ -59,23 +59,9 @@ CLASS ltcl_find_by_item IMPLEMENTATION.
       iv_object_type = 'TABL'
       iv_object_name = 'USR02' ).
 
-    BREAK-POINT.
-
-*    READ TABLE lt_results WITH KEY object = 'DTEL' obj_name = 'XMILOGID' TRANSPORTING NO FIELDS.
-*    cl_abap_unit_assert=>assert_subrc( ).
-*    READ TABLE lt_results WITH KEY object = 'DOMA' obj_name = 'XMILOGID' TRANSPORTING NO FIELDS.
-*    cl_abap_unit_assert=>assert_subrc( ).
-*
-*    READ TABLE lt_results WITH KEY object = 'TABL' obj_name = 'SXMILOGADM' TRANSPORTING NO FIELDS.
-*    cl_abap_unit_assert=>assert_subrc( ).
-*    READ TABLE lt_results WITH KEY object = 'TABL' obj_name = 'SXMIMSGRAW' TRANSPORTING NO FIELDS.
-*    cl_abap_unit_assert=>assert_subrc( ).
-*
-** not sure the result is the same across systems/versions
-*    cl_abap_unit_assert=>assert_number_between(
-*      lower  = 20
-*      upper  = 50
-*      number = lines( lt_results ) ).
+* the check tables should not be found by the dependency analysis, they are not relevant to abaplint
+    READ TABLE lt_results WITH KEY object = 'TABL' obj_name = 'SEC_POLICY_CUST' TRANSPORTING NO FIELDS.
+    cl_abap_unit_assert=>assert_subrc( exp = 4 ).
 
   ENDMETHOD.
 

--- a/src/deps/zcl_abaplint_deps_git.clas.abap
+++ b/src/deps/zcl_abaplint_deps_git.clas.abap
@@ -115,10 +115,13 @@ CLASS ZCL_ABAPLINT_DEPS_GIT IMPLEMENTATION.
     DATA lo_dep_ser TYPE REF TO zcl_abaplint_deps_serializer.
     DATA lt_tadir TYPE zif_abapgit_definitions=>ty_tadir_tt.
     DATA lt_local TYPE zif_abapgit_definitions=>ty_files_tt.
+    DATA ls_options TYPE zcl_abaplint_deps_find=>ty_options.
+
+    ls_options-max_level = mv_depth.
 
     CREATE OBJECT lo_dep_find
       EXPORTING
-        iv_max_level = mv_depth.
+        is_options = ls_options.
     CREATE OBJECT lo_dep_ser.
 
     lt_tadir = lo_dep_find->find_by_packages( mv_packages ).

--- a/src/zabaplint_list_deps.prog.abap
+++ b/src/zabaplint_list_deps.prog.abap
@@ -42,10 +42,14 @@ FORM run RAISING cx_static_check.
   DATA lv_lines TYPE n LENGTH 6.
   DATA lx_error TYPE REF TO zcx_abaplint_error.
   DATA lx_error2 TYPE REF TO zcx_abapgit_exception.
+  DATA ls_options TYPE zcl_abaplint_deps_find=>ty_options.
+
+
+  ls_options-max_level = p_depth.
 
   CREATE OBJECT lo_find
     EXPORTING
-      iv_max_level = p_depth.
+      is_options = ls_options.
 
   TRY.
       CASE abap_true.

--- a/src/zcl_abaplint_backend.clas.abap
+++ b/src/zcl_abaplint_backend.clas.abap
@@ -17,7 +17,7 @@ CLASS zcl_abaplint_backend DEFINITION
         start    TYPE ty_position,
       END OF ty_issue .
     TYPES:
-      ty_issues TYPE STANDARD TABLE OF ty_issue WITH KEY table_line.
+      ty_issues TYPE STANDARD TABLE OF ty_issue WITH KEY table_line .
     TYPES:
       BEGIN OF ty_message,
         error   TYPE abap_bool,
@@ -32,7 +32,8 @@ CLASS zcl_abaplint_backend DEFINITION
       RETURNING
         VALUE(rt_issues)  TYPE ty_issues
       RAISING
-        zcx_abaplint_error.
+        zcx_abaplint_error
+        zcx_abapgit_exception .
     METHODS ping
       RETURNING
         VALUE(rs_message) TYPE ty_message
@@ -42,7 +43,7 @@ CLASS zcl_abaplint_backend DEFINITION
       RETURNING
         VALUE(rv_json) TYPE string
       RAISING
-        zcx_abaplint_error.
+        zcx_abaplint_error .
     METHODS constructor
       IMPORTING
         !is_config TYPE zabaplint_glob_data OPTIONAL .
@@ -67,14 +68,14 @@ CLASS zcl_abaplint_backend DEFINITION
       RETURNING
         VALUE(rv_files) TYPE string
       RAISING
-        zcx_abaplint_error.
+        zcx_abaplint_error
+        zcx_abapgit_exception .
     METHODS build_files
       IMPORTING
         !iv_object_type TYPE trobjtype
         !iv_object_name TYPE sobj_name
       RETURNING
         VALUE(rv_files) TYPE string .
-
   PRIVATE SECTION.
     CONSTANTS:
       BEGIN OF c_uri,
@@ -86,7 +87,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abaplint_backend IMPLEMENTATION.
+CLASS ZCL_ABAPLINT_BACKEND IMPLEMENTATION.
 
 
   METHOD base64_encode.
@@ -240,26 +241,6 @@ CLASS zcl_abaplint_backend IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD ping.
-
-    DATA lx_error TYPE REF TO zcx_abaplint_error.
-    DATA lo_agent TYPE REF TO zcl_abaplint_backend_api_agent.
-    DATA li_json TYPE REF TO zif_ajson_reader.
-
-    lo_agent = zcl_abaplint_backend_api_agent=>create( ms_config-url ).
-
-    TRY.
-        li_json = lo_agent->request( c_uri-ping ).
-        rs_message-message = li_json->value_string( '' ).
-        rs_message-error   = abap_false.
-      CATCH zcx_abaplint_error INTO lx_error.
-        rs_message-message = lx_error->message.
-        rs_message-error   = abap_true.
-    ENDTRY.
-
-  ENDMETHOD.
-
-
   METHOD get_default_config.
 
     DATA lo_agent TYPE REF TO zcl_abaplint_backend_api_agent.
@@ -289,4 +270,23 @@ CLASS zcl_abaplint_backend IMPLEMENTATION.
 
   ENDMETHOD.
 
+
+  METHOD ping.
+
+    DATA lx_error TYPE REF TO zcx_abaplint_error.
+    DATA lo_agent TYPE REF TO zcl_abaplint_backend_api_agent.
+    DATA li_json TYPE REF TO zif_ajson_reader.
+
+    lo_agent = zcl_abaplint_backend_api_agent=>create( ms_config-url ).
+
+    TRY.
+        li_json = lo_agent->request( c_uri-ping ).
+        rs_message-message = li_json->value_string( '' ).
+        rs_message-error   = abap_false.
+      CATCH zcx_abaplint_error INTO lx_error.
+        rs_message-message = lx_error->message.
+        rs_message-error   = abap_true.
+    ENDTRY.
+
+  ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_abaplint_check.clas.abap
+++ b/src/zcl_abaplint_check.clas.abap
@@ -335,6 +335,8 @@ CLASS ZCL_ABAPLINT_CHECK IMPLEMENTATION.
             iv_object_name   = object_name ).
 
           output_issues( lt_issues ).
+        CATCH zcx_abapgit_exception.
+          ASSERT 0 = 1. " todo
         CATCH zcx_abaplint_error INTO lx_error.
           inform(
             p_test    = myname

--- a/src/zcl_abaplint_deps.clas.abap
+++ b/src/zcl_abaplint_deps.clas.abap
@@ -27,9 +27,12 @@ CLASS ZCL_ABAPLINT_DEPS IMPLEMENTATION.
 
     DATA lo_serializer TYPE REF TO zcl_abaplint_deps_serializer.
     DATA lo_find TYPE REF TO zcl_abaplint_deps_find.
+    DATA ls_options TYPE zcl_abaplint_deps_find=>ty_options.
 
     CREATE OBJECT lo_serializer.
-    CREATE OBJECT lo_find EXPORTING iv_max_level = iv_depth.
+
+    ls_options-max_level = iv_depth.
+    CREATE OBJECT lo_find EXPORTING is_options = ls_options.
 
     DATA lt_deps TYPE zif_abapgit_definitions=>ty_tadir_tt.
 


### PR DESCRIPTION
this adds an option `continue_into_sap` to dependency determination, by default its false

bugfixes for unit test in `ZCL_ABAPLINT_DEPS_FIND`

do not find SHLP

do not traverse into check tables for TABL objects