### PR TITLE
Fix ASSERTION_FAILED dump when adding non-existing package

### DIFF
--- a/src/zabaplint_ui.fugr.lzabaplint_uif01.abap
+++ b/src/zabaplint_ui.fugr.lzabaplint_uif01.abap
@@ -330,6 +330,12 @@ FORM add_raw.
 
   CREATE OBJECT lo_config.
   READ TABLE lt_fields INTO ls_field INDEX 1.
+
+  IF zcl_abapgit_factory=>get_sap_package( |{ ls_field-value }| )->exists( ) = abap_false.
+    MESSAGE e001(zabaplint) WITH ls_field-value.
+    RETURN.
+  ENDIF.
+
   lo_config->add_package( |{ ls_field-value }| ).
   lcl_tree_content=>refresh( ).
 


### PR DESCRIPTION
Trying to add a package to the SCI configuration that didn't exist resulted in dump