### PR TITLE
Fix type determination

### DIFF
--- a/src/zabaplint_ui.fugr.xml
+++ b/src/zabaplint_ui.fugr.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_FUGR" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>


### PR DESCRIPTION
Contains additions for type determination #153:
- Check if a program is a function group (SAPL...)
- Get the correct type of include structures (VIEW, ...)
- Skip class-specific types since DDIC types they refer to are already in wbcrossgt (<CLASS>\TY:<TYPE>)

Closes #156 and #164 