### PR TITLE
Display rules.abaplint.org for check and individual messages

### DIFF
--- a/src/zcl_abaplint_check.clas.abap
+++ b/src/zcl_abaplint_check.clas.abap
@@ -494,6 +494,7 @@ CLASS ZCL_ABAPLINT_CHECK IMPLEMENTATION.
 
     super->run_end( ).
 
+    " Get ping message which include abaplint backend version
     CREATE OBJECT lo_backend.
 
     TRY.
@@ -505,6 +506,7 @@ CLASS ZCL_ABAPLINT_CHECK IMPLEMENTATION.
         RETURN. "ignore
     ENDTRY.
 
+    " Output without object name
     object_type = '-'.
     object_name = '-'.
 

--- a/src/zcl_abaplint_check.clas.abap
+++ b/src/zcl_abaplint_check.clas.abap
@@ -160,13 +160,15 @@ CLASS ZCL_ABAPLINT_CHECK IMPLEMENTATION.
 
   METHOD get_message_text.
 
+    DATA ls_smsg TYPE LINE OF scimessages.
+
     IF p_code = c_no_config.
       p_text = 'No configuration found when looking at package hierarchy, &1'.
     ELSEIF p_code CP 'LINT_*'.
-      READ TABLE scimessages INTO smsg TRANSPORTING text
+      READ TABLE scimessages INTO ls_smsg TRANSPORTING text
         WITH TABLE KEY test = myname code = p_code.
       IF sy-subrc = 0.
-        p_text = smsg-text.
+        p_text = ls_smsg-text.
       ELSE.
         p_text = '&1 (&2)'.
       ENDIF.

--- a/src/zcl_abaplint_check.clas.abap
+++ b/src/zcl_abaplint_check.clas.abap
@@ -7,6 +7,11 @@ CLASS zcl_abaplint_check DEFINITION
 
     CLASS-METHODS class_constructor .
     METHODS constructor .
+    CLASS-METHODS get_rule
+      IMPORTING
+        !iv_code         TYPE sci_errc
+      RETURNING
+        VALUE(rv_result) TYPE string .
 
     METHODS consolidate_for_display
         REDEFINITION .
@@ -184,6 +189,18 @@ CLASS ZCL_ABAPLINT_CHECK IMPLEMENTATION.
     CREATE OBJECT p_result TYPE zcl_abaplint_result
       EXPORTING
         iv_kind = p_kind.
+
+  ENDMETHOD.
+
+
+  METHOD get_rule.
+
+    DATA ls_map TYPE ty_map.
+
+    READ TABLE gt_map INTO ls_map WITH KEY code = iv_code.
+    IF sy-subrc = 0.
+      rv_result = ls_map-rule.
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/zcl_abaplint_check.clas.abap
+++ b/src/zcl_abaplint_check.clas.abap
@@ -67,9 +67,7 @@ CLASS zcl_abaplint_check DEFINITION
       END OF ty_map .
 
     CLASS-DATA:
-      gv_start TYPE timestampl,
-      gv_end   TYPE timestampl,
-      gt_map   TYPE STANDARD TABLE OF ty_map WITH DEFAULT KEY.
+      gt_map TYPE STANDARD TABLE OF ty_map WITH DEFAULT KEY.
 
     METHODS add_messages .
     CLASS-METHODS init_mapping .

--- a/src/zcl_abaplint_configuration.clas.abap
+++ b/src/zcl_abaplint_configuration.clas.abap
@@ -134,7 +134,7 @@ CLASS ZCL_ABAPLINT_CONFIGURATION IMPLEMENTATION.
 
     SELECT * FROM zabaplint_pack
       INTO TABLE rt_data
-      ORDER BY PRIMARY KEY.
+      ORDER BY PRIMARY KEY.                             "#EC CI_NOWHERE
 
   ENDMETHOD.
 

--- a/src/zcl_abaplint_result.clas.abap
+++ b/src/zcl_abaplint_result.clas.abap
@@ -1,0 +1,72 @@
+CLASS zcl_abaplint_result DEFINITION
+  PUBLIC
+  INHERITING FROM cl_ci_result_program
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    METHODS constructor
+      IMPORTING
+        !iv_kind TYPE sychar01 .
+
+    METHODS if_ci_test~display_documentation
+        REDEFINITION .
+  PROTECTED SECTION.
+
+    METHODS get_text
+        REDEFINITION .
+  PRIVATE SECTION.
+
+ENDCLASS.
+
+
+
+CLASS ZCL_ABAPLINT_RESULT IMPLEMENTATION.
+
+
+  METHOD constructor.
+
+    super->constructor( p_kind              = iv_kind
+                        p_has_documentation = abap_true ).
+
+  ENDMETHOD.
+
+
+  METHOD get_text.
+
+    DATA lv_code TYPE sci_errc.
+
+    " Temporarily remove code so we get the message template from ZCL_ABAPLINT_CHECK
+    lv_code = result-code.
+    result-code = ''.
+
+    p_result = super->get_text( ).
+
+    result-code = lv_code.
+
+  ENDMETHOD.
+
+
+  METHOD if_ci_test~display_documentation.
+
+    cl_gui_frontend_services=>execute(
+      EXPORTING
+        document               = 'https://rules.abaplint.org/' && result-param2
+      EXCEPTIONS
+        cntl_error             = 1
+        error_no_gui           = 2
+        bad_parameter          = 3
+        file_not_found         = 4
+        path_not_found         = 5
+        file_extension_unknown = 6
+        error_execute_failed   = 7
+        synchronous_failed     = 8
+        not_supported_by_gui   = 9
+        OTHERS                 = 10 ).
+    IF sy-subrc <> 0.
+      RETURN.
+    ENDIF.
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/zcl_abaplint_result.clas.abap
+++ b/src/zcl_abaplint_result.clas.abap
@@ -39,7 +39,9 @@ CLASS ZCL_ABAPLINT_RESULT IMPLEMENTATION.
 
     " Temporarily remove code so we get the message template from ZCL_ABAPLINT_CHECK
     lv_code = result-code.
-    result-code = ''.
+    IF lv_code CP 'LINT_*'.
+      result-code = ''.
+    ENDIF.
 
     p_result = super->get_text( ).
 

--- a/src/zcl_abaplint_result.clas.abap
+++ b/src/zcl_abaplint_result.clas.abap
@@ -50,9 +50,17 @@ CLASS ZCL_ABAPLINT_RESULT IMPLEMENTATION.
 
   METHOD if_ci_test~display_documentation.
 
+    DATA lv_rule TYPE string.
+
+    IF result-param2 IS INITIAL.
+      lv_rule = zcl_abaplint_check=>get_rule( result-code ).
+    ELSE.
+      lv_rule = result-param2.
+    ENDIF.
+
     cl_gui_frontend_services=>execute(
       EXPORTING
-        document               = 'https://rules.abaplint.org/' && result-param2
+        document               = 'https://rules.abaplint.org/' && lv_rule
       EXCEPTIONS
         cntl_error             = 1
         error_no_gui           = 2

--- a/src/zcl_abaplint_result.clas.xml
+++ b/src/zcl_abaplint_result.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPLINT_RESULT</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abaplint - Result</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
Clicking on "i" icon for abaplint root and categories will display "rules.abaplint.org"

![image](https://user-images.githubusercontent.com/59966492/93713673-56ffed80-fb2b-11ea-9c3b-85d06c7bb6ce.png)

Clicking on "i" icon for individual messages will display "rules.abaplint.org/...rule..." 

![image](https://user-images.githubusercontent.com/59966492/93713626-1607d900-fb2b-11ea-94f4-321f1b4d0639.png)

Mapping is done via /api/v1/list_rules
https://github.com/mbtools/abaplint-sci-server/blob/master/src/api/list_rules.ts

Also fixes the display of rule description in ATC and ADT:

![image](https://user-images.githubusercontent.com/59966492/93714071-2f5e5480-fb2e-11ea-8e88-658419a2be31.png)

Closes #114 and https://github.com/abaplint/abaplint-sci-server/issues/21

Also adds abaplint version to output as info msg: 

![image](https://user-images.githubusercontent.com/59966492/93716126-c41b7f00-fb3b-11ea-8ad9-5117ebc6d157.png)

Closes #40 