### PR TITLE
Fix "invalid result" in case of new abaplint rules

### DIFF
--- a/src/zcl_abaplint_check.clas.abap
+++ b/src/zcl_abaplint_check.clas.abap
@@ -572,6 +572,8 @@ CLASS ZCL_ABAPLINT_CHECK IMPLEMENTATION.
       ENDCASE.
 
       rv_kind = <ls_map>-severity.
+    ELSE.
+      rv_kind = c_error.
     ENDIF.
 
     READ TABLE scimessages ASSIGNING <ls_msg> WITH KEY test = myname code = get_mapping( iv_rule ).


### PR DESCRIPTION
The situation can occur due to caching of API request. Restart of abaplint Server usually takes care of this, but this code avoids the problem.