### PR TITLE
Reduce size of XML

### DIFF
--- a/src/deps/zcl_abaplint_deps_serializer.clas.abap
+++ b/src/deps/zcl_abaplint_deps_serializer.clas.abap
@@ -112,22 +112,18 @@ CLASS ZCL_ABAPLINT_DEPS_SERIALIZER IMPLEMENTATION.
 
     lv_include = cl_oo_classname_service=>get_pubsec_name( |{ iv_class }| ).
     READ REPORT lv_include INTO lt_text.
-    LOOP AT lt_text INTO lv_text.
-      IF lv_text(1) = '*'.
-        CONTINUE.
-      ENDIF.
-      APPEND lv_text TO rt_code.
-    ENDLOOP.
+    ASSERT sy-subrc = 0.
+    " Remove comments
+    DELETE lt_text WHERE table_line CP '#**'.
+    APPEND LINES OF lt_text TO rt_code.
 
     IF lv_final = abap_false.
       lv_include = cl_oo_classname_service=>get_prosec_name( |{ iv_class }| ).
       READ REPORT lv_include INTO lt_text.
-      LOOP AT lt_text INTO lv_text.
-        IF lv_text(1) = '*'.
-          CONTINUE.
-        ENDIF.
-        APPEND lv_text TO rt_code.
-      ENDLOOP.
+      ASSERT sy-subrc = 0.
+      " Remove comments
+      DELETE lt_text WHERE table_line CP '#**'.
+      APPEND LINES OF lt_text TO rt_code.
     ENDIF.
 
     APPEND 'ENDCLASS.' TO rt_code.
@@ -406,6 +402,9 @@ CLASS ZCL_ABAPLINT_DEPS_SERIALIZER IMPLEMENTATION.
 
     SPLIT iv_string AT |\n| INTO TABLE lt_code.
 
+    " Remove comments
+    DELETE lt_code WHERE table_line CP '#**'.
+
     SCAN ABAP-SOURCE lt_code
       TOKENS INTO lt_tokens
       STRUCTURES INTO lt_structures
@@ -456,7 +455,8 @@ CLASS ZCL_ABAPLINT_DEPS_SERIALIZER IMPLEMENTATION.
     SPLIT iv_string AT |\n| INTO TABLE lt_strings.
 
     " Skip TEXT, SHORT_TEXT, STEXT, DDTEXT, SCRTEXT_S/M/L etc
-    DELETE lt_strings WHERE table_line CP '<*TEXT>*</*TEXT>' OR table_line CP '<SCRTEXT*>*</SCRTEXT*>'.
+    DELETE lt_strings WHERE table_line CP '*<*TEXT*>*</*TEXT*>*'.
+
     LOOP AT lt_strings INTO lv_string.
       IF lv_string = |   <DYNPROS>|
           OR lv_string = |   <CUA>|

--- a/src/deps/zcl_abaplint_deps_serializer.clas.abap
+++ b/src/deps/zcl_abaplint_deps_serializer.clas.abap
@@ -52,6 +52,9 @@ CLASS zcl_abaplint_deps_serializer DEFINITION
         !iv_class      TYPE clike
       RETURNING
         VALUE(rt_code) TYPE abaptxt255_tab .
+    METHODS build_intf
+      CHANGING
+        !cs_files TYPE zcl_abapgit_objects=>ty_serialization .
   PRIVATE SECTION.
 ENDCLASS.
 
@@ -70,7 +73,7 @@ CLASS ZCL_ABAPLINT_DEPS_SERIALIZER IMPLEMENTATION.
     DELETE cs_files-files WHERE filename CP '*.clas.locals_def.abap'.
     DELETE cs_files-files WHERE filename CP '*.clas.locals_imp.abap'.
     DELETE cs_files-files WHERE filename CP '*.clas.macros.abap'.
-    DELETE cs_files-files WHERE filename CP '*.clas.xml'. " todo?
+    DELETE cs_files-files WHERE filename CP '*.clas.xml'.
     DELETE cs_files-files WHERE filename CP '*.clas.testclasses.abap'.
 
     DATA lt_text TYPE abaptxt255_tab.
@@ -232,6 +235,11 @@ CLASS ZCL_ABAPLINT_DEPS_SERIALIZER IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD build_intf.
+    DELETE cs_files-files WHERE filename CP '*.intf.xml'.
+  ENDMETHOD.
+
+
   METHOD build_prog.
 
     DATA lv_filename TYPE string.
@@ -333,6 +341,8 @@ CLASS ZCL_ABAPLINT_DEPS_SERIALIZER IMPLEMENTATION.
         CASE ls_tadir-object.
           WHEN 'CLAS'.
             build_clas( CHANGING cs_files = ls_files_item ).
+          WHEN 'INTF'.
+            build_intf( CHANGING cs_files = ls_files_item ).
           WHEN 'FUGR'.
             build_fugr( CHANGING cs_files = ls_files_item ).
           WHEN 'PROG'.
@@ -342,7 +352,7 @@ CLASS ZCL_ABAPLINT_DEPS_SERIALIZER IMPLEMENTATION.
                     CHANGING cs_files_item = ls_files_item ).
 
             build_prog( CHANGING cs_files = ls_files_item ).
-          WHEN 'TABL' OR 'MSAG'.
+          WHEN 'TABL' OR 'MSAG' OR 'VIEW' OR 'DTEL' OR 'TTYP'.
             build_xml( CHANGING cs_files = ls_files_item ).
           WHEN OTHERS.
         ENDCASE.
@@ -445,8 +455,8 @@ CLASS ZCL_ABAPLINT_DEPS_SERIALIZER IMPLEMENTATION.
 
     SPLIT iv_string AT |\n| INTO TABLE lt_strings.
 
-    " Skip TEXT, SHORT_TEXT, STEXT, DDTEXT, etc
-    DELETE lt_strings WHERE table_line CP '<*TEXT>*</*TEXT>'.
+    " Skip TEXT, SHORT_TEXT, STEXT, DDTEXT, SCRTEXT_S/M/L etc
+    DELETE lt_strings WHERE table_line CP '<*TEXT>*</*TEXT>' OR table_line CP '<SCRTEXT*>*</SCRTEXT*>'.
     LOOP AT lt_strings INTO lv_string.
       IF lv_string = |   <DYNPROS>|
           OR lv_string = |   <CUA>|

--- a/src/zcl_abaplint_check.clas.abap
+++ b/src/zcl_abaplint_check.clas.abap
@@ -7,8 +7,6 @@ CLASS zcl_abaplint_check DEFINITION
 
     CLASS-METHODS class_constructor .
     METHODS constructor .
-    CLASS-METHODS get_ping .
-    CLASS-METHODS get_map .
     CLASS-METHODS get_rule
       IMPORTING
         !iv_code         TYPE sci_errc
@@ -29,9 +27,9 @@ CLASS zcl_abaplint_check DEFINITION
         REDEFINITION .
     METHODS run
         REDEFINITION .
-    METHODS run_begin
-        REDEFINITION .
     METHODS run_end
+        REDEFINITION .
+    METHODS run_begin
         REDEFINITION .
   PROTECTED SECTION.
 
@@ -46,8 +44,6 @@ CLASS zcl_abaplint_check DEFINITION
     CONSTANTS c_no_config TYPE sci_errc VALUE 'NO_CONFIG' ##NO_TEXT.
     CONSTANTS c_abaplint TYPE sci_errc VALUE 'ABAPLINT' ##NO_TEXT.
     CONSTANTS c_stats TYPE trobjtype VALUE '1STA' ##NO_TEXT.
-    CONSTANTS c_abaplint_ping TYPE sy-lisel VALUE 'ABAPLINT_PING' ##NO_TEXT.
-    CONSTANTS c_abaplint_map TYPE sy-lisel VALUE 'ABAPLINT_MAP' ##NO_TEXT.
 
     METHODS hash
       IMPORTING
@@ -72,13 +68,13 @@ CLASS zcl_abaplint_check DEFINITION
         severity TYPE sy-msgty,
       END OF ty_map .
 
-    CLASS-DATA gs_ping TYPE zcl_abaplint_backend=>ty_message .
     CLASS-DATA:
       gt_map TYPE STANDARD TABLE OF ty_map WITH DEFAULT KEY .
     DATA mo_cache TYPE REF TO zcl_abaplint_deps_cache .
     DATA ms_config TYPE zabaplint_glob_data .
 
     METHODS add_messages .
+    CLASS-METHODS init_mapping .
     METHODS get_mapping
       IMPORTING
         !iv_rule         TYPE string
@@ -103,8 +99,6 @@ CLASS ZCL_ABAPLINT_CHECK IMPLEMENTATION.
       ls_map TYPE ty_map,
       ls_msg TYPE scimessage.
 
-    get_map( ).
-
     LOOP AT gt_map INTO ls_map.
       CLEAR ls_msg.
       ls_msg-test = myname.
@@ -121,8 +115,7 @@ CLASS ZCL_ABAPLINT_CHECK IMPLEMENTATION.
 
   METHOD class_constructor.
 
-    get_ping( ).
-    get_map( ).
+    init_mapping( ).
 
   ENDMETHOD.
 
@@ -171,52 +164,9 @@ CLASS ZCL_ABAPLINT_CHECK IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD get_map.
-
-    DATA:
-      lo_backend TYPE REF TO zcl_abaplint_backend,
-      lt_rules   TYPE zcl_abaplint_backend=>ty_rules,
-      lv_code    TYPE n LENGTH 4,
-      ls_map     TYPE ty_map.
-
-    FIELD-SYMBOLS <ls_rule> LIKE LINE OF lt_rules.
-
-    IF gt_map IS INITIAL.
-      IMPORT gt_map = gt_map FROM MEMORY ID c_abaplint_map.
-      IF sy-subrc <> 0 OR gt_map IS INITIAL.
-        " Get a list of available rules from server
-        CREATE OBJECT lo_backend.
-        TRY.
-            lt_rules = lo_backend->list_rules( ).
-          CATCH zcx_abaplint_error.
-            " This will fallback to hashed rule names
-            RETURN.
-        ENDTRY.
-
-        " Number rules sequentially
-        LOOP AT lt_rules ASSIGNING <ls_rule>.
-          lv_code = lv_code + 1.
-          CLEAR ls_map.
-          ls_map-code = 'LINT_' && lv_code.
-          ls_map-rule = <ls_rule>-key.
-          ls_map-title = <ls_rule>-title.
-          " Set default severity. Actual severity is set in SET_MESSAGE_SEVERITY
-          ls_map-severity = 'E'.
-          INSERT ls_map INTO TABLE gt_map.
-        ENDLOOP.
-
-        EXPORT gt_map = gt_map TO MEMORY ID c_abaplint_map.
-      ENDIF.
-    ENDIF.
-
-  ENDMETHOD.
-
-
   METHOD get_mapping.
 
     DATA ls_map TYPE ty_map.
-
-    get_map( ).
 
     READ TABLE gt_map INTO ls_map WITH KEY rule = iv_rule.
     IF sy-subrc <> 0.
@@ -254,33 +204,6 @@ CLASS ZCL_ABAPLINT_CHECK IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD get_ping.
-
-    DATA:
-      lo_backend TYPE REF TO zcl_abaplint_backend.
-
-    IF gs_ping IS INITIAL.
-      IMPORT gs_ping = gs_ping FROM MEMORY ID c_abaplint_ping.
-      IF sy-subrc <> 0 OR gs_ping IS INITIAL.
-        " Get ping message which includes abaplint backend version
-        CREATE OBJECT lo_backend.
-        TRY.
-            gs_ping = lo_backend->ping( ).
-            IF gs_ping-error = abap_true.
-              RETURN.
-            ENDIF.
-          CATCH zcx_abaplint_error.
-            " This will fallback to hashed rule names
-            RETURN.
-        ENDTRY.
-
-        EXPORT gs_ping = gs_ping TO MEMORY ID c_abaplint_ping.
-      ENDIF.
-    ENDIF.
-
-  ENDMETHOD.
-
-
   METHOD get_result_node.
 
     CREATE OBJECT p_result TYPE zcl_abaplint_result
@@ -293,8 +216,6 @@ CLASS ZCL_ABAPLINT_CHECK IMPLEMENTATION.
   METHOD get_rule.
 
     DATA ls_map TYPE ty_map.
-
-    get_map( ).
 
     READ TABLE gt_map INTO ls_map WITH KEY code = iv_code.
     IF sy-subrc = 0.
@@ -358,6 +279,40 @@ CLASS ZCL_ABAPLINT_CHECK IMPLEMENTATION.
         iv_read_only = p_display.
 
     attributes_ok = abap_true.
+
+  ENDMETHOD.
+
+
+  METHOD init_mapping.
+
+    DATA:
+      lo_backend TYPE REF TO zcl_abaplint_backend,
+      lt_rules   TYPE zcl_abaplint_backend=>ty_rules,
+      lv_code    TYPE n LENGTH 4,
+      ls_map     TYPE ty_map.
+
+    FIELD-SYMBOLS <ls_rule> LIKE LINE OF lt_rules.
+
+    CREATE OBJECT lo_backend.
+
+    TRY.
+        lt_rules = lo_backend->list_rules( ).
+      CATCH zcx_abaplint_error.
+        " This will fallback to hashed rule names
+        RETURN.
+    ENDTRY.
+
+    " Number rules sequentially
+    LOOP AT lt_rules ASSIGNING <ls_rule>.
+      lv_code = lv_code + 1.
+      CLEAR ls_map.
+      ls_map-code = 'LINT_' && lv_code.
+      ls_map-rule = <ls_rule>-key.
+      ls_map-title = <ls_rule>-title.
+      " Set default severity. Actual severity is set in SET_MESSAGE_SEVERITY
+      ls_map-severity = 'E'.
+      INSERT ls_map INTO TABLE gt_map.
+    ENDLOOP.
 
   ENDMETHOD.
 
@@ -559,11 +514,25 @@ CLASS ZCL_ABAPLINT_CHECK IMPLEMENTATION.
 
   METHOD run_end.
 
+    DATA:
+      lo_backend TYPE REF TO zcl_abaplint_backend,
+      ls_message TYPE zcl_abaplint_backend=>ty_message.
+
     super->run_end( ).
 
     mo_cache->save( ).
 
-    get_ping( ).
+    " Get ping message which include abaplint backend version
+    CREATE OBJECT lo_backend.
+
+    TRY.
+        ls_message = lo_backend->ping( ).
+        IF ls_message-error = abap_true.
+          RETURN.
+        ENDIF.
+      CATCH zcx_abaplint_error.
+        RETURN. "ignore
+    ENDTRY.
 
     " Output without object name
     object_type = '-'.
@@ -574,7 +543,7 @@ CLASS ZCL_ABAPLINT_CHECK IMPLEMENTATION.
       p_sub_obj_name = '-'
       p_test         = myname
       p_kind         = c_note
-      p_param_1      = gs_ping-message
+      p_param_1      = ls_message-message
       p_param_2      = 'ping'
       p_code         = c_abaplint ).
 
@@ -586,8 +555,6 @@ CLASS ZCL_ABAPLINT_CHECK IMPLEMENTATION.
     FIELD-SYMBOLS:
       <ls_map> TYPE ty_map,
       <ls_msg> TYPE scimessage.
-
-    get_map( ).
 
     READ TABLE gt_map ASSIGNING <ls_map> WITH KEY rule = iv_rule.
     IF sy-subrc = 0.


### PR DESCRIPTION
- Remove INTF XML
- Remove text fields from MSAG (didn't work properly), VIEW, DTEL, TTYP
- Remove comments from PROG and CLAS
- For abaplint-sci dependencies, this reduced XML by about 10%.

Closes #201 and probably https://github.com/abaplint/abaplint-sci-client/issues/94 as well