### PR TITLE
Change "No configuration found" to warning

### DIFF
--- a/src/zcl_abaplint_check.clas.abap
+++ b/src/zcl_abaplint_check.clas.abap
@@ -524,7 +524,7 @@ CLASS ZCL_ABAPLINT_CHECK IMPLEMENTATION.
       inform(
         p_sub_obj_type = c_stats
         p_test         = myname
-        p_kind         = c_note
+        p_kind         = c_warning
         p_param_1      = |{ object_type } { object_name }|
         p_code         = c_no_config ).
     ELSE.


### PR DESCRIPTION
The previous "success/note" message was not visible in all tools. For example, abapGit would show that there no findings although abaplint was not configured:

![image](https://user-images.githubusercontent.com/59966492/96769422-1eaf3180-13ad-11eb-9eaa-3a62eb398013.png)

After change to "warning" in abapGit:

![image](https://user-images.githubusercontent.com/59966492/96769467-2cfd4d80-13ad-11eb-8b21-cacf20347e8a.png)
