### PR TITLE
Method 'PUT_ATTRIBUTES' is not implemented

### DIFF
--- a/src/zcl_abaplint_check.clas.abap
+++ b/src/zcl_abaplint_check.clas.abap
@@ -33,6 +33,8 @@ CLASS zcl_abaplint_check DEFINITION
         REDEFINITION .
     METHODS run_end
         REDEFINITION .
+    METHODS put_attributes
+        REDEFINITION .
   PROTECTED SECTION.
 
     TYPES:
@@ -618,4 +620,10 @@ CLASS zcl_abaplint_check IMPLEMENTATION.
     ENDIF.
 
   ENDMETHOD.
+
+
+  METHOD put_attributes.
+    RETURN.
+  ENDMETHOD.
+
 ENDCLASS.


### PR DESCRIPTION
Short dump when using abaplint sci client:
![image](https://user-images.githubusercontent.com/5233413/97207497-dc189b00-1798-11eb-94a0-97493616e8be.png)

It happens because:
![image](https://user-images.githubusercontent.com/5233413/97207591-f6eb0f80-1798-11eb-9725-b3a18072d66f.png)

The sci client worked perfectly after bypassing the `put_attributes`.