### PR TITLE
better handling of findings in includes

### DIFF
--- a/src/zcl_abaplint_check.clas.abap
+++ b/src/zcl_abaplint_check.clas.abap
@@ -464,9 +464,21 @@ CLASS ZCL_ABAPLINT_CHECK IMPLEMENTATION.
           rs_result-line = ls_position-start_line.
         ENDIF.
 
+      WHEN 'PROG'.
+        READ TABLE lt_tabl INDEX 1 INTO lv_name.
+        SELECT SINGLE subc FROM trdir INTO lv_subc WHERE name = lv_name.
+        IF sy-subrc = 0 AND lv_subc = 'I'.
+          rs_result-sub_obj_type = 'PROG'.
+          rs_result-sub_obj_name = lv_name.
+        ELSE.
+          rs_result-sub_obj_type = object_type.
+          rs_result-sub_obj_name = object_name.
+        ENDIF.
+
       WHEN OTHERS.
         rs_result-sub_obj_type = object_type.
         rs_result-sub_obj_name = object_name.
+
     ENDCASE.
 
   ENDMETHOD.

--- a/src/zcl_abaplint_check.clas.abap
+++ b/src/zcl_abaplint_check.clas.abap
@@ -485,13 +485,13 @@ CLASS ZCL_ABAPLINT_CHECK IMPLEMENTATION.
 
       TRANSLATE ls_issue-filename TO UPPER CASE.
       TRANSLATE ls_issue-filename USING '#/'.
-      IF NOT ls_issue-filename CP |*{ object_name }*|.
+      IF NOT ls_issue-filename CP |*{ object_name }.*|.
         ls_issue-message = |{ ls_issue-message }, { ls_issue-filename }|.
       ENDIF.
 
       lv_kind = set_message_severity(
-                  iv_rule     = ls_issue-key
-                  iv_severity = ls_issue-severity ).
+        iv_rule     = ls_issue-key
+        iv_severity = ls_issue-severity ).
 
       inform(
         p_sub_obj_type = ls_result-sub_obj_type


### PR DESCRIPTION
in case the object being checked is ZABAPGIT, and error is found in ZABAPGIT_TOP, the filename would not be reported, this is fixed now

#234