### PR TITLE
Correct link to abaplint server

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project enables [abaplint](https://abaplint.org) to be run in the context o
  
 ## Overview
 
-The integration requires two parts: The [abaplint Server](https://github.com/abaplint/abaplint-sci-client) and the abaplint Client (this project). When performing code checks through one of the supported editors or transactions, the abaplint Client will collect the necessary objects and dependencies and send them to the abaplint Server to be processed. The server responds with all of the abaplint findings, which are displayed like any other check results in the SAP tools.
+The integration requires two parts: The [abaplint Server](https://github.com/abaplint/abaplint-sci-server) and the abaplint Client (this project). When performing code checks through one of the supported editors or transactions, the abaplint Client will collect the necessary objects and dependencies and send them to the abaplint Server to be processed. The server responds with all of the abaplint findings, which are displayed like any other check results in the SAP tools.
 
 ![Components](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/abaplint/abaplint-sci-client/master/docs/components.iuml)
 


### PR DESCRIPTION
Changed incorrect link to abaplint server, it used to point to the abaplint client