### PR TITLE
Remove class_constructor in check class

### DIFF
--- a/src/zcl_abaplint_check.clas.abap
+++ b/src/zcl_abaplint_check.clas.abap
@@ -5,7 +5,6 @@ CLASS zcl_abaplint_check DEFINITION
 
   PUBLIC SECTION.
 
-    CLASS-METHODS class_constructor .
     METHODS constructor .
     CLASS-METHODS get_ping .
     CLASS-METHODS get_map .
@@ -117,14 +116,6 @@ CLASS ZCL_ABAPLINT_CHECK IMPLEMENTATION.
       ls_msg-pcom_alt = ''. "Pragma
       INSERT ls_msg INTO TABLE scimessages.
     ENDLOOP.
-
-  ENDMETHOD.
-
-
-  METHOD class_constructor.
-
-    get_ping( ).
-    get_map( ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
Fixes #268

All usages of the static variables `gs_ping` and `gt_map` that were initially filled using the class constructor also have calls to `get_ping` and `get_map` respectively. Therefore it should be fine to just remove the class constructor resulting in a later cache fill. That should result in less interruptions in the standard transactions that also call the class constructor mentioned in the issue.