### PR TITLE
Fix: #265 DBSQL_DUPLICATE_KEY_ERROR

### DIFF
--- a/src/zcl_abaplint_check.clas.abap
+++ b/src/zcl_abaplint_check.clas.abap
@@ -579,21 +579,6 @@ CLASS ZCL_ABAPLINT_CHECK IMPLEMENTATION.
 
     mo_cache->save( ).
 
-    get_ping( ).
-
-    " Output without object name
-    object_type = '-'.
-    object_name = '-'.
-
-    inform(
-      p_sub_obj_type = '-'
-      p_sub_obj_name = '-'
-      p_test         = myname
-      p_kind         = c_note
-      p_param_1      = gs_ping-message
-      p_param_2      = 'ping'
-      p_code         = c_abaplint ).
-
   ENDMETHOD.
 
 


### PR DESCRIPTION
If executed via ABAPGit with PARALLEL RUN enabled, having a PING per each object analyzed where both Object_Type and Object_Name = '-' causes duplicated records as described in #265