### PR TITLE
Exporting: Fix DOMA itself not considered

### DIFF
--- a/src/deps/zcl_abaplint_deps_find.clas.abap
+++ b/src/deps/zcl_abaplint_deps_find.clas.abap
@@ -964,7 +964,7 @@ CLASS zcl_abaplint_deps_find IMPLEMENTATION.
         OR ref_obj_type = 'TRAN'
         OR ref_obj_type = 'MSAG'
         OR ref_obj_type = 'FUGR'.
-    ELSEIF lv_obj_type = 'TTYP'.
+    ELSEIF lv_obj_type = 'TTYP' OR lv_obj_type = 'DOMA'.
       ls_tadir-ref_obj_name = is_object-obj_name.
       ls_tadir-ref_obj_type = is_object-object.
       APPEND ls_tadir TO rt_tadir.


### PR DESCRIPTION
Additional items of type domain (DOMA) are not being considered itself but only environmental objects during exporting dependencies.